### PR TITLE
[CityFinder] - #03 - Added CityListView and Search Bar

### DIFF
--- a/CityFinder/CityFinder.xcodeproj/xcshareddata/xcschemes/CityFinder.xcscheme
+++ b/CityFinder/CityFinder.xcodeproj/xcshareddata/xcschemes/CityFinder.xcscheme
@@ -55,7 +55,7 @@
       </Testables>
    </TestAction>
    <LaunchAction
-      buildConfiguration = "Debug"
+      buildConfiguration = "Release"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"

--- a/CityFinder/CityFinder/CityFinderApp.swift
+++ b/CityFinder/CityFinder/CityFinderApp.swift
@@ -32,7 +32,7 @@ struct CityFinderApp: App {
 
     var body: some Scene {
         WindowGroup {
-            HomeScreen(viewModel: cityViewModel)
+            HomeScreen(cityViewModel: cityViewModel)
                 .modelContainer(modelContainer)
         }
     }

--- a/CityFinder/CityFinder/CityFinderComponents/CityFinderText/CityFinderText.swift
+++ b/CityFinder/CityFinder/CityFinderComponents/CityFinderText/CityFinderText.swift
@@ -1,0 +1,16 @@
+//
+//  CityFinderText.swift
+//  CityFinder
+//
+//  Created by Ivan Alexander Valero on 08/03/2025.
+//
+
+import SwiftUI
+
+struct CityFinderText: View {
+    var text: String
+
+    var body: some View {
+        Text(text)
+    }
+}

--- a/CityFinder/CityFinder/Constants/CityFinderConstants.swift
+++ b/CityFinder/CityFinder/Constants/CityFinderConstants.swift
@@ -1,0 +1,22 @@
+//
+//  CityConstants.swift
+//  CityFinder
+//
+//  Created by Ivan Alexander Valero on 08/03/2025.
+//
+
+import Foundation
+
+struct CityFinderConstants {
+    static let lon = "Lon: "
+    static let lat = "Lat: "
+    static let longitude = "\(lon)<PLACEHOLDER>"
+    static let latitude = "\(lat)<PLACEHOLDER>"
+    static let cities = "Ciudades"
+    static let promptSearch = "Buscar ciudades..."
+    static let loadingProgress = "Loading cities..."
+}
+
+struct Constants {
+    static let placeholder = "<PLACEHOLDER>"
+}

--- a/CityFinder/CityFinder/Services/CityService/CityService.swift
+++ b/CityFinder/CityFinder/Services/CityService/CityService.swift
@@ -25,11 +25,12 @@ class CityService: CityServiceProtocol {
         let descriptor = FetchDescriptor<CityModel>()
 
         // Asegurar que la consulta se hace en el hilo correcto
-        let storedCities = try await MainActor.run {
+        let storedCities = await MainActor.run {
             try? modelContext.fetch(descriptor)
         }
 
         if let storedCities, !storedCities.isEmpty {
+            print("Cities: ", storedCities)
             return storedCities
         }
 

--- a/CityFinder/CityFinder/ViewModels/CityViewModel/CityViewModel.swift
+++ b/CityFinder/CityFinder/ViewModels/CityViewModel/CityViewModel.swift
@@ -9,28 +9,53 @@ import Foundation
 
 class CityViewModel: ObservableObject {
     @Published var cities: [CityModel] = []
+    @Published var filteredCities: [CityModel] = []
+    @Published var selectedCity: CityModel?
+    @Published var isLandscape: Bool = false
+    @Published var filter: String = "" {
+        didSet {
+            filterCities()
+        }
+    }
+    @Published var isLoading: Bool = false
+    @Published var errorMessage: String?
+
     private var cityService: CityServiceProtocol
 
     init(cityService: CityServiceProtocol) {
         self.cityService = cityService
         Task {
-            await self.loadCities()
+            await loadCities()
         }
     }
 
+@MainActor
     func loadCities() async {
+        self.isLoading = true
         do {
-            let cities = try await cityService.fetchCities()
-
+            let allCities = try await cityService.fetchCities()
+            // Actualiza la UI en el hilo principal
             await MainActor.run {
-                self.cities = cities
+                self.cities = allCities
+                self.filterCities()
+                self.isLoading = false
             }
         } catch let error as CityGenericError {
+            await MainActor.run {
+                self.isLoading = false
                 self.errorMessage = error.localizedDescription
+            }
         } catch {
             await MainActor.run {
+                self.isLoading = false
                 self.errorMessage = CityGenericError.errorDefaultMessage.errorMessage
             }
         }
+    }
+
+    private func filterCities() {
+        filteredCities = cities.filter {
+            $0.name.lowercased().hasPrefix(filter.lowercased())
+        }.sorted { $0.name < $1.name }
     }
 }

--- a/CityFinder/CityFinder/Views/CityListView/CityListView.swift
+++ b/CityFinder/CityFinder/Views/CityListView/CityListView.swift
@@ -1,0 +1,63 @@
+//
+//  CityListView.swift
+//  CityFinder
+//
+//  Created by Ivan Alexander Valero on 08/03/2025.
+//
+
+import SwiftUI
+
+struct CityListView: View {
+    @ObservedObject var cityViewModel: CityViewModel
+    @State private var showAlert = false
+
+    init(cityViewModel: CityViewModel) {
+        self.cityViewModel = cityViewModel
+    }
+
+    var body: some View {
+        NavigationView {
+            ScrollView {
+                if cityViewModel.isLoading {
+                    ProgressView(CityFinderConstants.loadingProgress)
+                        .progressViewStyle(CircularProgressViewStyle())
+                        .padding()
+                } else {
+                    LazyVStack(alignment: .leading, spacing: 10) {
+                        // Made use of LazyVStack: more efficient in terms of memory usage and rendering times
+                        ForEach(cityViewModel.filteredCities) { city in
+                            Button(action: {
+                                cityViewModel.selectedCity = city
+                            }) {
+                                VStack(alignment: .leading) {
+                                    CityFinderText(text: "\(city.name), \(city.country)")
+                                        .font(.headline)
+                                    CityFinderText(text: "\(CityFinderConstants.longitude.replacingOccurrences(of: Constants.placeholder, with: "\(city.lon)")), \(CityFinderConstants.latitude.replacingOccurrences(of: Constants.placeholder, with: "\(city.lat)"))")
+                                        .font(.subheadline)
+                                }
+                            }
+                            .accessibilityIdentifier("city-row-\(city.name)")
+                        }
+                    }
+                    .padding(.leading, 20)
+                    .tint(.black)
+                }
+            }
+            .searchable(text: $cityViewModel.filter, prompt: CityFinderConstants.promptSearch)
+            .navigationTitle(CityFinderConstants.cities)
+            .toolbarBackground(.white, for: .navigationBar)
+            .onChange(of: cityViewModel.errorMessage) {
+                self.showAlert = cityViewModel.errorMessage != nil
+            }
+        }
+        .onAppear {
+            Task {
+                await cityViewModel.loadCities()
+            }
+        }
+    }
+}
+
+#Preview {
+    CityListView(cityViewModel: CityViewModel(cityService: CityServiceMock()))
+}

--- a/CityFinder/CityFinder/Views/Home/HomeScreen.swift
+++ b/CityFinder/CityFinder/Views/Home/HomeScreen.swift
@@ -10,25 +10,13 @@ import SwiftUI
 struct HomeScreen: View {
     @ObservedObject var cityViewModel: CityViewModel
 
-    init(viewModel: CityViewModel) {
-        self.cityViewModel = viewModel
-    }
-
     var body: some View {
-        VStack {
-            if cityViewModel.cities.isEmpty {
-                Text("Loading...")
-            } else {
-                List(cityViewModel.cities) { city in
-                    Text(city.name)
-                }
-            }
-        }
-        .task {
-            await cityViewModel.loadCities()
+        Group {
+            CityListView(cityViewModel: cityViewModel)
         }
     }
 }
+
 #Preview {
-    HomeScreen(viewModel: CityViewModel(cityService: CityServiceMock()))
+    HomeScreen(cityViewModel: CityViewModel(cityService: CityServiceMock()))
 }


### PR DESCRIPTION
- se añadió un listado de ciudades ordenadas alfabéticamente
- ademas, se agrego un `search bar` para poder buscar y filtrar ciudades, teniendo como objetivo dicha consigna:

```
Definimos un "prefijo" como una subcadena que coincide con los caracteres iniciales de la cadena objetivo. Por ejemplo, dada la siguiente lista de ciudades:

- Alabama, US
- Albuquerque, US
- Anaheim, US
- Arizona, US
- Sydney, AU

Si el prefijo dado es "A", todas las ciudades excepto "Sydney" deben aparecer. Si el prefijo dado es "s", solo debe mostrarse "Sydney, AU".

Si el prefijo es "Al", deben mostrarse "Alabama, US" y "Albuquerque, US".

Si el prefijo es "Alb", solo debe mostrarse "Albuquerque, US".

```

- y teniendo en cuenta que la búsqueda es insensible a mayúsculas y minúsculas, y la lista se actualiza con cada carácter agregando o eliminando del filtro.

| Search bar             | City list             | Filter cities             |
|-------------------------------------|-------------------------------------|-------------------------------------|
| <img src="https://github.com/user-attachments/assets/196a99de-d3d7-4e74-a5d7-299b14a3c3d0" width="260"/>    | <img src="https://github.com/user-attachments/assets/b208af47-2b37-42db-94af-bbb551f8aae9" width="260"/> | <img src="https://github.com/user-attachments/assets/5b2476c4-7acb-488a-ab13-ac7fc0ca72e0" width="260"/>  

